### PR TITLE
Update scan-website.sh

### DIFF
--- a/scan-website.sh
+++ b/scan-website.sh
@@ -1,15 +1,15 @@
 website_url=$1
 scan_text=$2
-status_code=$(curl --silent --head $website_url | head -1 | awk '{print $2}')
+status_code=$(curl --silent --location --head --output /dev/null --write-out "%{http_code}" "${website_url}")
 
-if [ "$status_code" != "200" ]
-then
-    echo "Website is unreachable"
+if [ "${status_code}" != "200" ]; then
+    echo "Website is unreachable (${status_code})" >&2
     exit 1
 fi
 
-if [ -z $(curl --silent $website_url | grep -i "$2") ]
-then
-    echo "Input text was not found on website."
+if ! $(curl --silent --location "{$website_url}" | grep --quiet --ignore-case "${scan_text}"); then
+    echo "Text was not found on website" >&2
     exit 1
 fi
+
+exit 0


### PR DESCRIPTION
 - Follow redirects
 - Remove need for `head` and `awk` getting status code.
 - Use `scan_text` variable in `grep`
 - Use exit code from `grep` instead of possibly erroneous (because value wasn't surrounded in quotes) `-z` test (this error prompted the change)
 - Output errors to `stderr`
 - Explicitly `exit 0`