### PR TITLE
Add insecure option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   scan-for-text:
     description: "Specify the string that has to be scanned"
     required: true
+  insecure:
+    description: "Set to true to disable TSL certificate checking"
+    default: false
 runs:
   using: "composite"
   steps:
@@ -17,5 +20,5 @@ runs:
       shell: bash
     - run: chmod +x ${{ github.action_path }}/scan-website.sh
       shell: bash
-    - run: ${{ github.action_path }}/scan-website.sh ${{ inputs.web-url }} ${{ inputs.scan-for-text }}
+    - run: ${{ github.action_path }}/scan-website.sh ${{ inputs.insecure }} ${{ inputs.web-url }} ${{ inputs.scan-for-text }}
       shell: bash

--- a/scan-website.sh
+++ b/scan-website.sh
@@ -1,13 +1,25 @@
-website_url=$1
-scan_text=$2
-status_code=$(curl --silent --location --head --output /dev/null --write-out "%{http_code}" "${website_url}")
+insecure=$1
+website_url=$2
+scan_text=$3
+
+curl_options="--silent --location --head --output /dev/null --write-out %{http_code}"
+if [ $insecure == "true" ]; then
+    curl_options="--insecure ${curl_options}"
+fi
+
+status_code=$(curl ${curl_options} "${website_url}")
 
 if [ "${status_code}" != "200" ]; then
     echo "Website is unreachable (${status_code})" >&2
     exit 1
 fi
 
-if ! curl --silent --location "{$website_url}" | grep --quiet --ignore-case "${scan_text}"; then
+curl_options="--silent --location"
+if [ $insecure == "true" ]; then
+    curl_options="--insecure ${curl_options}"
+fi
+
+if ! curl ${curl_options} "{$website_url}" | grep --quiet --ignore-case "${scan_text}"; then
     echo "Text was not found on website" >&2
     exit 1
 fi


### PR DESCRIPTION
This option, defaulted to false, passes `-k` to curl and allows it to work in
cases where the website being checked is deployed with self-signed certificates
in CI.
